### PR TITLE
Clean up MPL library definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
 # delayed-seq
-Experiments with parallel delayed sequences using MPL and C++
+This repo contains all code necessary for reproducing the experiments in the
+following paper:
+
+> Parallel Block-Delayed Sequences.
+> Sam Westrick, Mike Rainey, Daniel Anderson, and Guy E. Blelloch.
+> PPoPP 2022
+
+It includes code for both
+[MPL](https://github.com/MPLLang/mpl) and C++, including both the
+delayed-sequences library and all benchmarks.
+
+An artifact was published with the paper, and is available on
+[Zenodo](https://zenodo.org/record/5733288). The version of this repo used
+to generate the artifact is preserved on the
+[ppopp22-artifact](https://github.com/mpllang/delayed-seq/tree/ppopp22-artifact)
+branch. **If you are interested in reproducing experimental results from the
+paper, we recommending using the artifact directly.**
+
+The [main](https://github.com/mpllang/delayed-seq/tree/main) branch includes
+improvements made to the libraries and benchmarks after the artifact was
+published. These changes include:
+  * For MPL, a cleaned-up library implementation which is easier to understand
+  and maintain. The new library code is available at
+  [`ml/lib/NewDelayedSeq.sml`](https://github.com/MPLLang/delayed-seq/blob/main/ml/lib/NewDelayedSeq.sml).
+  When compiling a benchmark, use `new-delay` for the cleaned-up library.
+  (For example, `cd ml && make bfs.new-delay.mpl-latest.bin`.)
+  * Small performance improvements to a few benchmarks.
 
 ## Setup
 

--- a/ml/bench/bestcut/new-delay/BC.sml
+++ b/ml/bench/bestcut/new-delay/BC.sml
@@ -1,0 +1,2 @@
+structure BC = MkBestCut (NewDelayedSeq)
+

--- a/ml/bench/bestcut/new-delay/sources.mlb
+++ b/ml/bench/bestcut/new-delay/sources.mlb
@@ -1,0 +1,5 @@
+../../../lib/sources.mlb
+../Event.sml
+../MkBestCut.sml
+BC.sml
+../main.sml

--- a/ml/bench/bfs/new-delay/BFS.sml
+++ b/ml/bench/bfs/new-delay/BFS.sml
@@ -1,0 +1,1 @@
+structure BFS = MkBFS(NewDelayedSeq)

--- a/ml/bench/bfs/new-delay/sources.mlb
+++ b/ml/bench/bfs/new-delay/sources.mlb
@@ -1,0 +1,5 @@
+../../../lib/sources.mlb
+../MkBFS.sml
+../SerialBFS.sml
+BFS.sml
+../main.sml

--- a/ml/bench/bignum-add/new-delay/Add.sml
+++ b/ml/bench/bignum-add/new-delay/Add.sml
@@ -1,0 +1,1 @@
+structure Add = MkAdd (NewDelayedSeq)

--- a/ml/bench/bignum-add/new-delay/sources.mlb
+++ b/ml/bench/bignum-add/new-delay/sources.mlb
@@ -1,0 +1,6 @@
+../../../lib/sources.mlb
+../Bignum.sml
+../MkAdd.sml
+Add.sml
+../SequentialAdd.sml
+../main.sml

--- a/ml/bench/filter/new-delay/Filter.sml
+++ b/ml/bench/filter/new-delay/Filter.sml
@@ -1,0 +1,1 @@
+structure Filter = MkFilter (NewDelayedSeq)

--- a/ml/bench/filter/new-delay/sources.mlb
+++ b/ml/bench/filter/new-delay/sources.mlb
@@ -1,0 +1,4 @@
+../../../lib/sources.mlb
+../MkFilter.sml
+Filter.sml
+../main.sml

--- a/ml/bench/grep/MkGrep.sml
+++ b/ml/bench/grep/MkGrep.sml
@@ -81,7 +81,8 @@ struct
       val s = Seq.fromArraySeq s
       val n = Seq.length s
 
-      val idx = Seq.filter (isNewline o Seq.nth s) (Seq.tabulate (fn i => i) n)
+      val idx =
+        Seq.force (Seq.filter (isNewline o Seq.nth s) (Seq.tabulate (fn i => i) n))
       (* val idx =
         Seq.mapOption
           (fn i => if isNewline (Seq.nth s i) then SOME i else NONE)

--- a/ml/bench/grep/new-delay/Grep.sml
+++ b/ml/bench/grep/new-delay/Grep.sml
@@ -1,0 +1,1 @@
+structure Grep = MkGrep (NewDelayedSeq)

--- a/ml/bench/grep/new-delay/sources.mlb
+++ b/ml/bench/grep/new-delay/sources.mlb
@@ -1,0 +1,4 @@
+../../../lib/sources.mlb
+../MkGrep.sml
+Grep.sml
+../main.sml

--- a/ml/bench/integrate/new-delay/DelayIntegrate.sml
+++ b/ml/bench/integrate/new-delay/DelayIntegrate.sml
@@ -1,0 +1,1 @@
+structure DelayIntegrate = MkIntegrate (NewDelayedSeq)

--- a/ml/bench/integrate/new-delay/sources.mlb
+++ b/ml/bench/integrate/new-delay/sources.mlb
@@ -1,0 +1,8 @@
+../../../lib/sources.mlb
+../MkIntegrate.sml
+local
+  DelayIntegrate.sml
+in
+  structure Integrate = DelayIntegrate
+end
+../main.sml

--- a/ml/bench/linearrec/new-delay/LinearRec.sml
+++ b/ml/bench/linearrec/new-delay/LinearRec.sml
@@ -1,0 +1,1 @@
+structure LinearRec = MkLinearRec (NewDelayedSeq)

--- a/ml/bench/linearrec/new-delay/sources.mlb
+++ b/ml/bench/linearrec/new-delay/sources.mlb
@@ -1,0 +1,4 @@
+../../../lib/sources.mlb
+../MkLinearRec.sml
+LinearRec.sml
+../main.sml

--- a/ml/bench/linefit/new-delay/LineFit.sml
+++ b/ml/bench/linefit/new-delay/LineFit.sml
@@ -1,0 +1,1 @@
+structure LineFit = MkLineFit (NewDelayedSeq)

--- a/ml/bench/linefit/new-delay/sources.mlb
+++ b/ml/bench/linefit/new-delay/sources.mlb
@@ -1,0 +1,4 @@
+../../../lib/sources.mlb
+../MkLineFit.sml
+LineFit.sml
+../main.sml

--- a/ml/bench/mcss-prefixes/new-delay/MCSS.sml
+++ b/ml/bench/mcss-prefixes/new-delay/MCSS.sml
@@ -1,0 +1,1 @@
+structure MCSS = MkAllPrefixScanMCSS (NewDelayedSeq)

--- a/ml/bench/mcss-prefixes/new-delay/sources.mlb
+++ b/ml/bench/mcss-prefixes/new-delay/sources.mlb
@@ -1,0 +1,4 @@
+../../../lib/sources.mlb
+../MkAllPrefixScanMCSS.sml
+MCSS.sml
+../main.sml

--- a/ml/bench/mcss/new-delay/DelayMCSS.sml
+++ b/ml/bench/mcss/new-delay/DelayMCSS.sml
@@ -1,0 +1,1 @@
+structure DelayMCSS = MkMapReduceMCSS (NewDelayedSeq)

--- a/ml/bench/mcss/new-delay/sources.mlb
+++ b/ml/bench/mcss/new-delay/sources.mlb
@@ -1,0 +1,8 @@
+../../../lib/sources.mlb
+../MkMapReduceMCSS.sml
+local
+  DelayMCSS.sml
+in
+  structure MCSS = DelayMCSS
+end
+../main.sml

--- a/ml/bench/parens/new-delay/DelayParens.sml
+++ b/ml/bench/parens/new-delay/DelayParens.sml
@@ -1,0 +1,1 @@
+structure DelayParens = MkParens (NewDelayedSeq)

--- a/ml/bench/parens/new-delay/sources.mlb
+++ b/ml/bench/parens/new-delay/sources.mlb
@@ -1,0 +1,8 @@
+../../../lib/sources.mlb
+../MkParens.sml
+local
+  DelayParens.sml
+in
+  structure Parens = DelayParens
+end
+../main.sml

--- a/ml/bench/primes/MkPrimes.sml
+++ b/ml/bench/primes/MkPrimes.sml
@@ -23,7 +23,7 @@ struct
 
         fun isPrime i = (Seq.nth flags i = 0w1)
       in
-        Seq.filter isPrime (Seq.tabulate (fn i => i+2) (n-1))
+        Seq.force (Seq.filter isPrime (Seq.tabulate (fn i => i+2) (n-1)))
       end
 
   fun primes n =

--- a/ml/bench/primes/new-delay/DelayPrimes.sml
+++ b/ml/bench/primes/new-delay/DelayPrimes.sml
@@ -1,0 +1,1 @@
+structure DelayPrimes = MkPrimes (NewDelayedSeq)

--- a/ml/bench/primes/new-delay/sources.mlb
+++ b/ml/bench/primes/new-delay/sources.mlb
@@ -1,0 +1,8 @@
+../../../lib/sources.mlb
+../MkPrimes.sml
+local
+  DelayPrimes.sml
+in
+  structure Primes = DelayPrimes
+end
+../main.sml

--- a/ml/bench/quickhull/new-delay/Quickhull.sml
+++ b/ml/bench/quickhull/new-delay/Quickhull.sml
@@ -1,0 +1,1 @@
+structure Quickhull = MkQuickhull (NewDelayedSeq)

--- a/ml/bench/quickhull/new-delay/sources.mlb
+++ b/ml/bench/quickhull/new-delay/sources.mlb
@@ -1,0 +1,9 @@
+../../../lib/sources.mlb
+local
+  ../MkPurishSplit.sml
+in
+  functor MkSplit = MkPurishSplit
+end
+../MkQuickhull.sml
+Quickhull.sml
+../main.sml

--- a/ml/bench/sparse-mxv/new-delay/MXV.sml
+++ b/ml/bench/sparse-mxv/new-delay/MXV.sml
@@ -1,0 +1,1 @@
+structure MXV = MkMXV (NewDelayedSeq)

--- a/ml/bench/sparse-mxv/new-delay/sources.mlb
+++ b/ml/bench/sparse-mxv/new-delay/sources.mlb
@@ -1,0 +1,4 @@
+../../../lib/sources.mlb
+../MkMXV.sml
+MXV.sml
+../main.sml

--- a/ml/bench/tokens-two-scan/new-delay/Tokens.sml
+++ b/ml/bench/tokens-two-scan/new-delay/Tokens.sml
@@ -1,0 +1,1 @@
+structure Tokens = MkTokens (NewDelayedSeq)

--- a/ml/bench/tokens-two-scan/new-delay/sources.mlb
+++ b/ml/bench/tokens-two-scan/new-delay/sources.mlb
@@ -1,0 +1,4 @@
+../../../lib/sources.mlb
+../MkTokens.sml
+Tokens.sml
+../main.sml

--- a/ml/bench/tokens/new-delay/Tokens.sml
+++ b/ml/bench/tokens/new-delay/Tokens.sml
@@ -1,0 +1,1 @@
+structure Tokens = MkTokens (NewDelayedSeq)

--- a/ml/bench/tokens/new-delay/sources.mlb
+++ b/ml/bench/tokens/new-delay/sources.mlb
@@ -1,0 +1,4 @@
+../../../lib/sources.mlb
+../MkTokens.sml
+Tokens.sml
+../main.sml

--- a/ml/bench/wc/new-delay/WC.sml
+++ b/ml/bench/wc/new-delay/WC.sml
@@ -1,0 +1,1 @@
+structure WC = MkWC (NewDelayedSeq)

--- a/ml/bench/wc/new-delay/sources.mlb
+++ b/ml/bench/wc/new-delay/sources.mlb
@@ -1,0 +1,4 @@
+../../../lib/sources.mlb
+../MkWC.sml
+WC.sml
+../main.sml

--- a/ml/config/mpl-latest-space.json
+++ b/ml/config/mpl-latest-space.json
@@ -1,6 +1,10 @@
 {
   "compiler": "mpl",
-  "mpl-switch-commit": "74627b2cb0c2e132c64adfe24adc4190d8a163e8",
-  "flags": [],
+  "mpl-switch-commit": "ae0f8fa07ae5ec693516ead0a4c09b7bd9cea2e0",
+  "flags": [
+    "-polyvariance", "true",
+    "-polyvariance-hofo", "false",
+    "-polyvariance-small", "100"
+  ],
   "compat": "mpl"
 }

--- a/ml/config/mpl-latest.json
+++ b/ml/config/mpl-latest.json
@@ -1,6 +1,10 @@
 {
   "compiler": "mpl",
-  "mpl-switch-commit": "74627b2cb0c2e132c64adfe24adc4190d8a163e8",
-  "flags": [],
+  "mpl-switch-commit": "ae0f8fa07ae5ec693516ead0a4c09b7bd9cea2e0",
+  "flags": [
+    "-polyvariance", "true",
+    "-polyvariance-hofo", "false",
+    "-polyvariance-small", "100"
+  ],
   "compat": "mpl"
 }

--- a/ml/lib/DelayedSeq.sml
+++ b/ml/lib/DelayedSeq.sml
@@ -1,8 +1,9 @@
 structure DelayedSeq =
 struct
 
-  val for = Util.for
+  structure Stream = DelayedStream
 
+  val for = Util.for
   val par = ForkJoin.par
   val parfor = ForkJoin.parfor
   val alloc = ForkJoin.alloc
@@ -29,209 +30,7 @@ struct
     fun nth a i = sub (a, i)
   end
 
-
-  (* Using given offsets, find which inner sequence contains index [k] *)
-  fun indexSearch (start, stop, offset: int -> int) k =
-    case stop-start of
-      0 =>
-        raise Fail "NewDelayedSeq.indexSearch: should not have hit 0"
-    | 1 =>
-        start
-    | n =>
-        let
-          val mid = start + (n div 2)
-        in
-          if k < offset mid then
-            indexSearch (start, mid, offset) k
-          else
-            indexSearch (mid, stop, offset) k
-        end
-
-
   (* ======================================================================= *)
-
-
-  structure Stream:>
-  sig
-    type 'a t
-    type 'a stream = 'a t
-
-    val tabulate: (int -> 'a) -> 'a stream
-    val map: ('a -> 'b) -> 'a stream -> 'b stream
-    val mapIdx: (int * 'a -> 'b) -> 'a stream -> 'b stream
-    val zipWith: ('a * 'b -> 'c) -> 'a stream * 'b stream -> 'c stream
-    val iteratePrefixes: ('b * 'a -> 'b) -> 'b -> 'a stream -> 'b stream
-    val iteratePrefixesIncl: ('b * 'a -> 'b) -> 'b -> 'a stream -> 'b stream
-
-    val applyIdx: int * 'a stream -> (int * 'a -> unit) -> unit
-    val iterate: ('b * 'a -> 'b) -> 'b -> int * 'a stream -> 'b
-
-    val makeBlockStreams:
-      { numChildren: int
-      , offset: int -> int
-      , getElem: int -> int -> 'a
-      }
-      -> (int -> 'a stream)
-
-  end =
-  struct
-
-    (** A stream is a generator for a stateful trickle function:
-      *   trickle = stream ()
-      *   x0 = trickle 0
-      *   x1 = trickle 1
-      *   x2 = trickle 2
-      *   ...
-      *
-      *  The integer argument is just an optimization (it could be packaged
-      *  up into the state of the trickle function, but doing it this
-      *  way is more efficient). Requires passing `i` on the ith call
-      *  to trickle.
-      *)
-    type 'a t = unit -> int -> 'a
-    type 'a stream = 'a t
-
-
-    fun tabulate f =
-      fn () => f
-
-
-    fun map g stream =
-      fn () =>
-        let
-          val trickle = stream ()
-        in
-          g o trickle
-        end
-
-
-    fun mapIdx g stream =
-      fn () =>
-        let
-          val trickle = stream ()
-        in
-          fn idx => g (idx, trickle idx)
-        end
-
-
-    fun applyIdx (length, stream) g =
-      let
-        val trickle = stream ()
-        fun loop i =
-          if i >= length then () else (g (i, trickle i); loop (i+1))
-      in
-        loop 0
-      end
-
-
-    fun iterate g b (length, stream) =
-      let
-        val trickle = stream ()
-        fun loop b i =
-          if i >= length then b else loop (g (b, trickle i)) (i+1)
-      in
-        loop b 0
-      end
-
-
-    fun iteratePrefixes g b stream =
-      fn () =>
-        let
-          val trickle = stream ()
-          val stuff = ref b
-        in
-          fn idx =>
-            let
-              val acc = !stuff
-              val elem = trickle idx
-              val acc' = g (acc, elem)
-            in
-              stuff := acc';
-              acc
-            end
-        end
-
-
-    fun iteratePrefixesIncl g b stream =
-      fn () =>
-        let
-          val trickle = stream ()
-          val stuff = ref b
-        in
-          fn idx =>
-            let
-              val acc = !stuff
-              val elem = trickle idx
-              val acc' = g (acc, elem)
-            in
-              stuff := acc';
-              acc'
-            end
-        end
-
-
-    fun zipWith g (s1, s2) =
-      fn () =>
-        let
-          val trickle1 = s1 ()
-          val trickle2 = s2 ()
-        in
-          fn idx => g (trickle1 idx, trickle2 idx)
-        end
-
-
-    fun makeBlockStreams
-          { numChildren: int
-          , offset: int -> int
-          , getElem: int -> int -> 'a
-          } =
-      let
-        fun getBlock blockIdx =
-          let
-            val lo = blockIdx * blockSize
-            val firstOuterIdx = indexSearch (0, numChildren, offset) lo
-            (* val firstInnerIdx = lo - offset firstOuterIdx *)
-
-            fun advanceUntilNonEmpty i =
-              if i >= numChildren orelse offset i <> offset (i+1) then
-                i
-              else
-                advanceUntilNonEmpty (i+1)
-          in
-            fn () =>
-              let
-                val outerIdx = ref firstOuterIdx
-                (* val innerIdx = ref firstInnerIdx *)
-              in
-                fn idx =>
-                  let
-                    val i = !outerIdx
-                    val j = lo + idx - offset i
-                    (* val j = !innerIdx *)
-                    val elem = getElem i j
-                  in
-                    if offset i + j + 1 < offset (i+1) then
-                      (* innerIdx := j+1 *) ()
-                    else
-                      ( outerIdx := advanceUntilNonEmpty (i+1)
-                      (* ; innerIdx := 0 *)
-                      );
-
-                    elem
-                  end
-              end
-          end
-
-      in
-        getBlock
-      end
-
-
-  end
-
-
-  (* ======================================================================= *)
-
 
   datatype 'a flat =
     Full of 'a AS.t
@@ -472,7 +271,8 @@ struct
       fun offset i = A.nth offsets i
       val getBlock =
         Stream.makeBlockStreams
-          { numChildren = numChildren
+          { blockSize = blockSize
+          , numChildren = numChildren
           , offset = offset
           , getElem = (fn i => fn j => flatNth (A.nth children i) j)
           }
@@ -562,7 +362,8 @@ struct
       fun offset i = A.nth offsets i
       val getBlock =
         Stream.makeBlockStreams
-          { numChildren = nb
+          { blockSize = blockSize
+          , numChildren = nb
           , offset = offset
           , getElem = (fn i => fn j => A.nth results (i*blockSize + j))
           }

--- a/ml/lib/DelayedStream.sml
+++ b/ml/lib/DelayedStream.sml
@@ -128,11 +128,7 @@ struct
       val trickle = stream ()
 
       fun loop (data, next) i =
-        if i >= length then
-          (data, next)
-        else if next >= Array.length data then
-          loop (resize data, next) i
-        else
+        if i < length andalso next < Array.length data then
           let
             val x = trickle i
           in
@@ -143,8 +139,12 @@ struct
             else
               loop (data, next) (i+1)
           end
+        else if next >= Array.length data then
+          loop (resize data, next) i
+        else
+          (data, next)
 
-      val (data, count) = loop (ForkJoin.alloc 100, 0) 0
+      val (data, count) = loop (ForkJoin.alloc 10, 0) 0
     in
       ArraySlice.slice (data, 0, SOME count)
     end

--- a/ml/lib/DelayedStream.sml
+++ b/ml/lib/DelayedStream.sml
@@ -1,0 +1,201 @@
+structure DelayedStream :>
+sig
+  type 'a t
+  type 'a stream = 'a t
+
+  (** `indexSearch (start, stop, offsetFn) k` returns which inner sequence
+    * contains index `k`. The tuple arg defines a sequence of offsets.
+    *)
+  val indexSearch: int * int * (int -> int) -> int -> int
+
+  val tabulate: (int -> 'a) -> 'a stream
+  val map: ('a -> 'b) -> 'a stream -> 'b stream
+  val mapIdx: (int * 'a -> 'b) -> 'a stream -> 'b stream
+  val zipWith: ('a * 'b -> 'c) -> 'a stream * 'b stream -> 'c stream
+  val iteratePrefixes: ('b * 'a -> 'b) -> 'b -> 'a stream -> 'b stream
+  val iteratePrefixesIncl: ('b * 'a -> 'b) -> 'b -> 'a stream -> 'b stream
+
+  val applyIdx: int * 'a stream -> (int * 'a -> unit) -> unit
+  val iterate: ('b * 'a -> 'b) -> 'b -> int * 'a stream -> 'b
+
+  val makeBlockStreams:
+    { blockSize: int
+    , numChildren: int
+    , offset: int -> int
+    , getElem: int -> int -> 'a
+    }
+    -> (int -> 'a stream)
+
+end =
+struct
+
+  (* Using given offsets, find which inner sequence contains index [k] *)
+  fun indexSearch (start, stop, offset: int -> int) k =
+    case stop-start of
+      0 =>
+        raise Fail "DelayedStream.indexSearch: should not have hit 0"
+    | 1 =>
+        start
+    | n =>
+        let
+          val mid = start + (n div 2)
+        in
+          if k < offset mid then
+            indexSearch (start, mid, offset) k
+          else
+            indexSearch (mid, stop, offset) k
+        end
+
+  (** A stream is a generator for a stateful trickle function:
+    *   trickle = stream ()
+    *   x0 = trickle 0
+    *   x1 = trickle 1
+    *   x2 = trickle 2
+    *   ...
+    *
+    *  The integer argument is just an optimization (it could be packaged
+    *  up into the state of the trickle function, but doing it this
+    *  way is more efficient). Requires passing `i` on the ith call
+    *  to trickle.
+    *)
+  type 'a t = unit -> int -> 'a
+  type 'a stream = 'a t
+
+
+  fun tabulate f =
+    fn () => f
+
+
+  fun map g stream =
+    fn () =>
+      let
+        val trickle = stream ()
+      in
+        g o trickle
+      end
+
+
+  fun mapIdx g stream =
+    fn () =>
+      let
+        val trickle = stream ()
+      in
+        fn idx => g (idx, trickle idx)
+      end
+
+
+  fun applyIdx (length, stream) g =
+    let
+      val trickle = stream ()
+      fun loop i =
+        if i >= length then () else (g (i, trickle i); loop (i+1))
+    in
+      loop 0
+    end
+
+
+  fun iterate g b (length, stream) =
+    let
+      val trickle = stream ()
+      fun loop b i =
+        if i >= length then b else loop (g (b, trickle i)) (i+1)
+    in
+      loop b 0
+    end
+
+
+  fun iteratePrefixes g b stream =
+    fn () =>
+      let
+        val trickle = stream ()
+        val stuff = ref b
+      in
+        fn idx =>
+          let
+            val acc = !stuff
+            val elem = trickle idx
+            val acc' = g (acc, elem)
+          in
+            stuff := acc';
+            acc
+          end
+      end
+
+
+  fun iteratePrefixesIncl g b stream =
+    fn () =>
+      let
+        val trickle = stream ()
+        val stuff = ref b
+      in
+        fn idx =>
+          let
+            val acc = !stuff
+            val elem = trickle idx
+            val acc' = g (acc, elem)
+          in
+            stuff := acc';
+            acc'
+          end
+      end
+
+
+  fun zipWith g (s1, s2) =
+    fn () =>
+      let
+        val trickle1 = s1 ()
+        val trickle2 = s2 ()
+      in
+        fn idx => g (trickle1 idx, trickle2 idx)
+      end
+
+
+  fun makeBlockStreams
+        { blockSize: int
+        , numChildren: int
+        , offset: int -> int
+        , getElem: int -> int -> 'a
+        } =
+    let
+      fun getBlock blockIdx =
+        let
+          val lo = blockIdx * blockSize
+          val firstOuterIdx = indexSearch (0, numChildren, offset) lo
+          (* val firstInnerIdx = lo - offset firstOuterIdx *)
+
+          fun advanceUntilNonEmpty i =
+            if i >= numChildren orelse offset i <> offset (i+1) then
+              i
+            else
+              advanceUntilNonEmpty (i+1)
+        in
+          fn () =>
+            let
+              val outerIdx = ref firstOuterIdx
+              (* val innerIdx = ref firstInnerIdx *)
+            in
+              fn idx =>
+                let
+                  val i = !outerIdx
+                  val j = lo + idx - offset i
+                  (* val j = !innerIdx *)
+                  val elem = getElem i j
+                in
+                  if offset i + j + 1 < offset (i+1) then
+                    (* innerIdx := j+1 *) ()
+                  else
+                    ( outerIdx := advanceUntilNonEmpty (i+1)
+                    (* ; innerIdx := 0 *)
+                    );
+
+                  elem
+                end
+            end
+        end
+
+    in
+      getBlock
+    end
+
+
+end

--- a/ml/lib/NewDelayedSeq.sml
+++ b/ml/lib/NewDelayedSeq.sml
@@ -1,0 +1,296 @@
+structure NewDelayedSeq: SEQUENCE =
+struct
+
+  structure Stream = DelayedStream
+
+  val for = Util.for
+  val par = ForkJoin.par
+  val parfor = ForkJoin.parfor
+  val alloc = ForkJoin.alloc
+
+  val gran = 5000
+  val blockSize = 10000
+  fun numBlocks n = Util.ceilDiv n blockSize
+
+  structure A =
+  struct
+    open Array
+    type 'a t = 'a array
+    fun nth a i = sub (a, i)
+  end
+
+  structure AS =
+  struct
+    open ArraySlice
+    type 'a t = 'a slice
+    fun nth a i = sub (a, i)
+  end
+
+
+  type 'a rad = int * int * (int -> 'a)
+  type 'a bid = int * (int -> 'a Stream.t)
+  datatype 'a seq =
+    Full of 'a AS.t
+  | Rad of 'a rad
+  | Bid of 'a bid
+
+  type 'a t = 'a seq
+
+
+  fun radlength (start, stop, _) = stop-start
+  fun radnth (start, _, f) i = f (start+i)
+
+
+  fun length s =
+    case s of
+      Full slice => AS.length slice
+    | Rad rad => radlength rad
+    | Bid (n, _) => n
+
+
+  fun nth s i =
+    case s of
+      Full slice => AS.nth slice i
+    | Rad rad => radnth rad i
+    | Bid (n, getBlock) =>
+        let
+          val bidx = i div blockSize
+        in
+          Stream.nth (getBlock bidx) (i mod blockSize)
+        end
+
+
+  fun bidify (s: 'a seq) : 'a bid =
+    let
+      fun block start nth b =
+        Stream.tabulate (fn i => nth (start + b*blockSize + i))
+    in
+      case s of
+        Full slice =>
+          let
+            val (a, start, n) = AS.base slice
+          in
+            (n, block start (A.nth a))
+          end
+
+      | Rad (start, stop, nth) =>
+          (stop-start, block start nth)
+
+      | Bid xx => xx
+    end
+
+
+  fun applyIdx (s: 'a seq) (g: int * 'a -> unit) =
+    let
+      val (n, getBlock) = bidify s
+    in
+      parfor 1 (0, numBlocks n) (fn i =>
+        let
+          val lo = i*blockSize
+          val hi = Int.min (lo+blockSize, n)
+        in
+          Stream.applyIdx (hi-lo, getBlock i) (fn (j, x) => g (lo+j, x))
+        end)
+    end
+
+
+  fun apply (s: 'a seq) (g: 'a -> unit) =
+    applyIdx s (fn (_, x) => g x)
+
+
+  fun reify s =
+    let
+      val a = alloc (length s)
+    in
+      applyIdx s (fn (i, x) => A.update (a, i, x));
+      AS.full a
+    end
+
+
+  fun force s = Full (reify s)
+
+
+  fun radify s =
+    case s of
+      Full slice =>
+        let
+          val (a, i, n) = AS.base slice
+        in
+          (i, i+n, fn j => A.nth a (i+j))
+        end
+
+    | Rad xx => xx
+
+    | Bid (n, blocks) =>
+        radify (force s)
+
+
+  fun tabulate f n =
+    Rad (0, n, f)
+
+
+  fun fromList xs =
+    Full (AS.full (Array.fromList xs))
+
+
+  fun % xs =
+    fromList xs
+
+
+  fun singleton x =
+    Rad (0, 1, fn _ => x)
+
+
+  fun $ x =
+    singleton x
+
+
+  fun empty () =
+    fromList []
+
+
+  fun fromArraySeq a =
+    Full a
+
+
+  fun range (i, j) =
+    Rad (i, j, fn k => k)
+
+
+  fun toArraySeq s =
+    case s of
+      Full x => x
+    | _ => reify s
+
+
+  fun map f s =
+    case s of
+      Full _ => map f (Rad (radify s))
+    | Rad (i, j, g) => Rad (i, j, f o g)
+    | Bid (n, getBlock) => Bid (n, Stream.map f o getBlock)
+
+
+  fun mapIdx f s =
+    case s of
+      Full _ => mapIdx f (Rad (radify s))
+    | Rad (i, j, g) => Rad (0, j-i, fn k => f (k, g (i+k)))
+    | Bid (n, getBlock) =>
+        Bid (n, fn b =>
+          Stream.mapIdx (fn (i, x) => f (b*blockSize + i, x)) (getBlock b))
+
+
+  fun enum s =
+    mapIdx (fn (i,x) => (i,x)) s
+
+
+  fun flatten (ss: 'a seq seq) : 'a seq =
+    let
+      val numChildren = length ss
+      val children: 'a rad AS.t = reify (map radify ss)
+      val offsets =
+        SeqBasis.scan gran op+ 0 (0, numChildren) (radlength o AS.nth children)
+      val totalLen = A.nth offsets numChildren
+      fun offset i = A.nth offsets i
+
+      val getBlock =
+        Stream.makeBlockStreams
+          { blockSize = blockSize
+          , numChildren = numChildren
+          , offset = offset
+          , getElem = (fn i => fn j => radnth (AS.nth children i) j)
+          }
+    in
+      Bid (totalLen, getBlock)
+    end
+
+
+  fun filter f (s: 'a seq) =
+    let
+      val (n, getBlock) = bidify s
+      val packed: 'a rad array =
+        SeqBasis.tabulate 1 (0, numBlocks n) (fn b =>
+          let
+            val lo = b*blockSize
+            val hi = Int.min (lo+blockSize, n)
+          in
+            radify (Full (Stream.pack f (hi-lo, getBlock b)))
+          end)
+      val offsets =
+        SeqBasis.scan gran op+ 0 (0, numBlocks n) (radlength o A.nth packed)
+      val totalLen = A.nth offsets (numBlocks n)
+      fun offset i = A.nth offsets i
+
+      val getBlock =
+        Stream.makeBlockStreams
+          { blockSize = blockSize
+          , numChildren = numBlocks n
+          , offset = offset
+          , getElem = (fn i =>
+              let val child = A.nth packed i
+              in radnth child
+              end)
+          }
+    in
+      Bid (totalLen, getBlock)
+    end
+
+
+  fun inject (s, u) =
+    let
+      val a = reify s
+      val (base, i, _) = AS.base a
+    in
+      apply u (fn (j, x) => Array.update (base, i+j, x));
+      Full a
+    end
+
+
+  (* ===================================================================== *)
+
+  exception NYI
+  exception Range
+  exception Size
+
+  datatype 'a listview = NIL | CONS of 'a * 'a seq
+  datatype 'a treeview = EMPTY | ONE of 'a | PAIR of 'a seq * 'a seq
+
+  type 'a ord = 'a * 'a -> order
+  type 'a t = 'a seq
+
+  fun append x = raise NYI
+  fun filterIdx x = raise NYI
+
+  fun iterate x = raise NYI
+  fun iterateIdx x = raise NYI
+  fun reduce x = raise NYI
+  fun scan x = raise NYI
+  fun scanIncl x = raise NYI
+  fun mapOption x = raise NYI
+  fun rev x = raise NYI
+  fun subseq x = raise NYI
+  fun toList x = raise NYI
+  fun toString x = raise NYI
+  fun zip x = raise NYI
+  fun zipWith x = raise NYI
+
+
+  fun argmax x = raise NYI
+  fun collate x = raise NYI
+  fun collect x = raise NYI
+  fun drop x = raise NYI
+  fun equal x = raise NYI
+  fun iteratePrefixes x = raise NYI
+  fun iteratePrefixesIncl x = raise NYI
+  fun merge x = raise NYI
+  fun sort x = raise NYI
+  fun splitHead x = raise NYI
+  fun splitMid x = raise NYI
+  fun take x = raise NYI
+  fun update x = raise NYI
+  fun zipWith3 x = raise NYI
+
+  fun filterSome x = raise NYI
+  fun foreach x = raise NYI
+  fun foreachG x = raise NYI
+
+end

--- a/ml/lib/NewDelayedSeq.sml
+++ b/ml/lib/NewDelayedSeq.sml
@@ -324,6 +324,36 @@ struct
         end
 
 
+  fun iterate f z s =
+    case s of
+      Full xx => SeqBasis.foldl f z (0, length s) (AS.nth xx)
+    | Rad xx => SeqBasis.foldl f z (0, length s) (radnth xx)
+    | Bid (n, getBlock) =>
+        Util.loop (0, numBlocks n) z (fn (z, b) =>
+          Stream.iterate f z (getBlockSize b n, getBlock b))
+
+
+  fun rev s =
+    let
+      val n = length s
+      val rads = radify s
+    in
+      tabulate (fn i => radnth rads (n-i-1)) n
+    end
+
+
+  fun append (s, t) =
+    let
+      val n = length s
+      val m = length t
+
+      val rads = radify s
+      val radt = radify t
+
+      fun elem i = if i < n then radnth rads i else radnth radt (i-n)
+    in
+      tabulate elem (n+m)
+    end
 
 
   (* ===================================================================== *)
@@ -334,12 +364,9 @@ struct
   type 'a ord = 'a * 'a -> order
   type 'a t = 'a seq
 
-  fun append x = raise NYI
   fun filterIdx x = raise NYI
 
-  fun iterate x = raise NYI
   fun iterateIdx x = raise NYI
-  fun rev x = raise NYI
   fun subseq x = raise NYI
   fun toList x = raise NYI
   fun toString x = raise NYI

--- a/ml/lib/NewDelayedSeq.sml
+++ b/ml/lib/NewDelayedSeq.sml
@@ -5,7 +5,7 @@ struct
   exception Range
   exception Size
 
-  structure Stream = DelayedStream
+  (* structure Stream = DelayedStream *)
 
   val for = Util.for
   val par = ForkJoin.par
@@ -356,6 +356,28 @@ struct
     end
 
 
+  fun subseq s (i, len) =
+    if i < 0 orelse len < 0 orelse i+len > length s then
+      raise Subscript
+    else
+      let
+        val n = length s
+        val (start, stop, nth) = radify s
+      in
+        Rad (start+i, start+i+len, nth)
+      end
+
+
+  fun take s n = subseq s (0, n)
+  fun drop s n = subseq s (n, length s - n)
+
+
+  fun toList s =
+    List.rev (iterate (fn (elems, x) => x :: elems) [] s)
+
+  fun toString f s =
+    "[" ^ String.concatWith "," (toList (map f s)) ^ "]"
+
   (* ===================================================================== *)
 
   datatype 'a listview = NIL | CONS of 'a * 'a seq
@@ -365,17 +387,11 @@ struct
   type 'a t = 'a seq
 
   fun filterIdx x = raise NYI
-
   fun iterateIdx x = raise NYI
-  fun subseq x = raise NYI
-  fun toList x = raise NYI
-  fun toString x = raise NYI
-
 
   fun argmax x = raise NYI
   fun collate x = raise NYI
   fun collect x = raise NYI
-  fun drop x = raise NYI
   fun equal x = raise NYI
   fun iteratePrefixes x = raise NYI
   fun iteratePrefixesIncl x = raise NYI
@@ -383,7 +399,6 @@ struct
   fun sort x = raise NYI
   fun splitHead x = raise NYI
   fun splitMid x = raise NYI
-  fun take x = raise NYI
   fun update x = raise NYI
   fun zipWith3 x = raise NYI
 
@@ -395,5 +410,5 @@ end
 
 
 
-(* structure NewDelayedSeq = MkDelayedSeq (DelayedStream) *)
-structure NewDelayedSeq = MkDelayedSeq (RecursiveStream)
+structure NewDelayedSeq = MkDelayedSeq (DelayedStream)
+(* structure NewDelayedSeq = MkDelayedSeq (RecursiveStream) *)

--- a/ml/lib/NewDelayedSeq.sml
+++ b/ml/lib/NewDelayedSeq.sml
@@ -1,4 +1,4 @@
-structure NewDelayedSeq: SEQUENCE =
+functor MkDelayedSeq (Stream: STREAM) : SEQUENCE =
 struct
 
   exception NYI
@@ -365,3 +365,8 @@ struct
   fun foreachG x = raise NYI
 
 end
+
+
+
+(* structure NewDelayedSeq = MkDelayedSeq (DelayedStream) *)
+structure NewDelayedSeq = MkDelayedSeq (RecursiveStream)

--- a/ml/lib/OffsetSearch.sml
+++ b/ml/lib/OffsetSearch.sml
@@ -1,0 +1,26 @@
+structure OffsetSearch:
+sig
+  (** `indexSearch (start, stop, offsetFn) k` returns which inner sequence
+    * contains index `k`. The tuple arg defines a sequence of offsets.
+    *)
+  val indexSearch: int * int * (int -> int) -> int -> int
+end =
+struct
+
+  fun indexSearch (start, stop, offset: int -> int) k =
+    case stop-start of
+      0 =>
+        raise Fail "OffsetSearch.indexSearch: should not have hit 0"
+    | 1 =>
+        start
+    | n =>
+        let
+          val mid = start + (n div 2)
+        in
+          if k < offset mid then
+            indexSearch (start, mid, offset) k
+          else
+            indexSearch (mid, stop, offset) k
+        end
+
+end

--- a/ml/lib/RadSeq.sml
+++ b/ml/lib/RadSeq.sml
@@ -2,7 +2,7 @@ structure RadSeq =
 struct
 
   open DelayedSeq
-  val indexSearch = DelayedStream.indexSearch
+  val indexSearch = OffsetSearch.indexSearch
 
   fun flatten (ss: 'a seq seq): 'a seq =
     let

--- a/ml/lib/RadSeq.sml
+++ b/ml/lib/RadSeq.sml
@@ -2,6 +2,7 @@ structure RadSeq =
 struct
 
   open DelayedSeq
+  val indexSearch = DelayedStream.indexSearch
 
   fun flatten (ss: 'a seq seq): 'a seq =
     let

--- a/ml/lib/RecursiveStream.sml
+++ b/ml/lib/RecursiveStream.sml
@@ -1,0 +1,181 @@
+structure RecursiveStream :> STREAM =
+struct
+
+  (** Intended use: when the stream is consumed, the indices are provided
+    * as input.
+    *
+    * For example, if `stream` represents elements x0,x1,...
+    *   val S a = stream
+    *   val (x0, S b) = a 0
+    *   val (x1, S c) = b 1
+    *   val (x2, S d) = c 2
+    *   ...
+    *
+    * Requiring the index in this way is just an optimization: we know that all
+    * streams require at least an index as state, so we can save storing one
+    * piece of state by instead providing this only as needed.
+    *)
+  datatype 'a stream = S of int -> 'a * ('a stream)
+  type 'a t = 'a stream
+
+  fun nth stream i =
+    let
+      fun loop j (S g) =
+        let
+          val (first, rest) = g j
+        in
+          if j >= i then first else loop (j+1) rest
+        end
+    in
+      loop 0 stream
+    end
+
+  fun tabulate f = S (fn i => (f i, tabulate f))
+
+  fun map f (S g) =
+    S (fn i =>
+      let
+        val (first, rest) = g i
+      in
+        (f first, map f rest)
+      end)
+
+  fun mapIdx f (S g) =
+    S (fn i =>
+      let
+        val (first, rest) = g i
+      in
+        (f (i, first), mapIdx f rest)
+      end)
+
+  fun zipWith f (S g, S h) =
+    S (fn i =>
+      let
+        val (gfirst, grest) = g i
+        val (hfirst, hrest) = h i
+      in
+        (f (gfirst, hfirst), zipWith f (grest, hrest))
+      end)
+
+  fun iteratePrefixes f z (S g) =
+    S (fn i =>
+      let
+        val (first, rest) = g i
+        val z' = f (z, first)
+      in
+        (z, iteratePrefixes f z' rest)
+      end)
+
+  fun iteratePrefixesIncl f z (S g) =
+    S (fn i =>
+      let
+        val (first, rest) = g i
+        val z' = f (z, first)
+      in
+        (z', iteratePrefixesIncl f z' rest)
+      end)
+
+  fun applyIdx (n, stream) f =
+    let
+      fun loop i (S g) =
+        if i >= n then () else
+        let
+          val (first, rest) = g i
+        in
+          f (i, first);
+          loop (i+1) rest
+        end
+    in
+      loop 0 stream
+    end
+
+  fun iterate f z (n, stream) =
+    let
+      fun loop acc i (S g) =
+        if i >= n then acc else
+        let
+          val (first, rest) = g i
+          val acc' = f (acc, first)
+        in
+          loop acc' (i+1) rest
+        end
+    in
+      loop z 0 stream
+    end
+
+  fun resize arr =
+    let
+      val newCapacity = 2 * Array.length arr
+      val dst = ForkJoin.alloc newCapacity
+    in
+      Array.copy {src = arr, dst = dst, di = 0};
+      dst
+    end
+
+  fun pack f (length, stream) =
+    let
+      fun loop (data, next) i (S g) =
+        if i < length andalso next < Array.length data then
+          let
+            val (first, rest) = g i
+          in
+            case f first of
+              SOME y =>
+                ( Array.update (data, next, y)
+                ; loop (data, next+1) (i+1) rest
+                )
+            | NONE =>
+                loop (data, next) (i+1) rest
+          end
+
+        else if next >= Array.length data then
+          loop (resize data, next) i (S g)
+
+        else
+          (data, next)
+
+      val (data, count) = loop (ForkJoin.alloc 10, 0) 0 stream
+    in
+      ArraySlice.slice (data, 0, SOME count)
+    end
+
+
+  fun makeBlockStreams
+        { blockSize: int
+        , numChildren: int
+        , offset: int -> int
+        , getElem: int -> int -> 'a
+        } =
+    let
+      fun getBlock blockIdx =
+        let
+          fun advanceUntilNonEmpty i =
+            if i >= numChildren orelse offset i <> offset (i+1) then
+              i
+            else
+              advanceUntilNonEmpty (i+1)
+
+          val lo = blockIdx * blockSize
+
+          fun walk i =
+            S (fn idx =>
+              let
+                val j = lo + idx - offset i
+                val elem = getElem i j
+              in
+                if offset i + j + 1 < offset (i+1) then
+                  (elem, walk i)
+                else
+                  (elem, walk (advanceUntilNonEmpty (i+1)))
+              end)
+
+          val firstOuterIdx =
+            OffsetSearch.indexSearch (0, numChildren, offset) lo
+        in
+          walk firstOuterIdx
+        end
+    in
+      getBlock
+    end
+
+end

--- a/ml/lib/STREAM.sml
+++ b/ml/lib/STREAM.sml
@@ -1,0 +1,27 @@
+signature STREAM =
+sig
+  type 'a t
+  type 'a stream = 'a t
+
+  val nth: 'a stream -> int -> 'a
+
+  val tabulate: (int -> 'a) -> 'a stream
+  val map: ('a -> 'b) -> 'a stream -> 'b stream
+  val mapIdx: (int * 'a -> 'b) -> 'a stream -> 'b stream
+  val zipWith: ('a * 'b -> 'c) -> 'a stream * 'b stream -> 'c stream
+  val iteratePrefixes: ('b * 'a -> 'b) -> 'b -> 'a stream -> 'b stream
+  val iteratePrefixesIncl: ('b * 'a -> 'b) -> 'b -> 'a stream -> 'b stream
+
+  val applyIdx: int * 'a stream -> (int * 'a -> unit) -> unit
+  val iterate: ('b * 'a -> 'b) -> 'b -> int * 'a stream -> 'b
+
+  val pack: ('a -> 'b option) -> (int * 'a stream) -> 'b ArraySlice.slice
+
+  val makeBlockStreams:
+    { blockSize: int
+    , numChildren: int
+    , offset: int -> int
+    , getElem: int -> int -> 'a
+    }
+    -> (int -> 'a stream)
+end

--- a/ml/lib/sources.mlb
+++ b/ml/lib/sources.mlb
@@ -13,6 +13,7 @@ in
   structure Seq = ArraySequence
   structure ArraySequence
 end
+DelayedStream.sml
 DelayedSeq.sml
 RadSeq.sml
 FuncSequence.sml

--- a/ml/lib/sources.mlb
+++ b/ml/lib/sources.mlb
@@ -15,6 +15,7 @@ in
 end
 DelayedStream.sml
 DelayedSeq.sml
+NewDelayedSeq.sml
 RadSeq.sml
 FuncSequence.sml
 BinarySearch.sml

--- a/ml/lib/sources.mlb
+++ b/ml/lib/sources.mlb
@@ -13,7 +13,10 @@ in
   structure Seq = ArraySequence
   structure ArraySequence
 end
+OffsetSearch.sml
+STREAM.sml
 DelayedStream.sml
+RecursiveStream.sml
 DelayedSeq.sml
 NewDelayedSeq.sml
 RadSeq.sml


### PR DESCRIPTION
`ml/lib/NewDelayedSeq.sml` contains a much simpler implementation of the MPL delayed sequences. Performance is similar to the original implementation, although the new implementation does generally need the `-polyvariance-hofo false` compile-time setting for good performance. `-polyvariance-small 100` helps too. Both of these have been added to the `mpl-latest` configuration.

This patch also includes a few other small improvements.